### PR TITLE
Use tokenized paths to determine unmount ancestors

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,6 +387,19 @@ module.exports = createStore =>
 
 		store.mount = mount.bind(null, null);
 
+		function isAncestor(path, possibleAncestor) {
+			path = path.split('.');
+			possibleAncestor = possibleAncestor.split('.');
+
+			for (let i = 0; i < possibleAncestor.length; i++) {
+				if (path[i] !== possibleAncestor[i]) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
 		function unmount(host, path) {
 			path = host ? `${host}.${path}` : path;
 
@@ -396,7 +409,7 @@ module.exports = createStore =>
 
 			const toUnmount = Array.from(mounts.keys())
 				.filter(key => {
-					return key.startsWith(path);
+					return isAncestor(key, path);
 				})
 				.sort((key1, key2) => {
 					return key1.split('.').length < key2.split('.').length;

--- a/test/unmount.js
+++ b/test/unmount.js
@@ -175,6 +175,35 @@ tap.test('unmount()', t => {
 		t.end();
 	});
 
+	t.test('does not dispatch an UNMOUNT action for paths with same prefix',
+		t => {
+			const store = redux.createStore(state => state, {}, reduxMountStore);
+			const path = 'path';
+			const unrelatedPath = 'pathtwo';
+			const anotherUnrelatedPath = 'pathtwo.foo';
+
+			store.mount(path);
+			store.mount(unrelatedPath);
+			store.mount(anotherUnrelatedPath);
+
+			sinon.stub(store, 'dispatch');
+			store.unmount(path);
+
+			t.ok(store.dispatch.neverCalledWithMatch({
+				payload: {
+					path: unrelatedPath
+				}
+			}), 'UNMOUNT action not dispatched for paths with same prefix');
+
+			t.ok(store.dispatch.neverCalledWithMatch({
+				payload: {
+					path: anotherUnrelatedPath
+				}
+			}), 'UNMOUNT action not dispatched for paths with same prefix');
+
+			t.end();
+		});
+
 	t.test('reduction', t => {
 		const rootReducer = sinon.stub().returnsArg(0);
 		const store = redux.createStore(rootReducer, {}, reduxMountStore);


### PR DESCRIPTION
When asked to unmount a path, we must check if it has any descendant paths and
unmount those first. Previously we looked for descendants by checking all
mounted paths to see if they started with the path to unmount. Unfortunately, we
did this via string comparison, with the result that `path10` was considered a
descendant of `path1`.

Instead, split the paths and compare by path segment.

[fix #5]