### PR TITLE
Immutable object transactions

### DIFF
--- a/lib/object-path-immutable-transaction.js
+++ b/lib/object-path-immutable-transaction.js
@@ -55,6 +55,10 @@ function createTransaction(source) {
 
 	const transaction = {
 		set: function set(path, value) {
+			if (committed) {
+				throw new Error('Cannot call `set` on a committed transaction');
+			}
+
 			if (arguments.length < 2) {
 				return;
 			}
@@ -68,6 +72,10 @@ function createTransaction(source) {
 		},
 
 		del: function del(path) {
+			if (committed) {
+				throw new Error('Cannot call `del` on a committed transaction');
+			}
+
 			if (arguments.length < 1) {
 				return;
 			}
@@ -81,6 +89,10 @@ function createTransaction(source) {
 		},
 
 		push: function push(path, value) {
+			if (committed) {
+				throw new Error('Cannot call `push` on a committed transaction');
+			}
+
 			if (arguments.length < 2) {
 				return;
 			}
@@ -92,6 +104,10 @@ function createTransaction(source) {
 		},
 
 		assign: function assign(path, value) {
+			if (committed) {
+				throw new Error('Cannot call `assign` on a committed transaction');
+			}
+
 			if (arguments.length < 2) {
 				return;
 			}

--- a/lib/object-path-immutable-transaction.js
+++ b/lib/object-path-immutable-transaction.js
@@ -1,0 +1,98 @@
+'use strict';
+const _assign = require('lodash.assign');
+const objectPath = require('object-path');
+const _isArray = require('lodash.isarray');
+const _isPlainObject = require('lodash.isplainobject');
+
+function ensureCloned(path, source, dest) {
+	if (!_isArray(path)) {
+		path = ('' + path).split('.');
+	}
+
+	// ensure all ancestor path segments are cloned
+	for (let i = 0; i < path.length; i++) {
+		if (dest[path[i]] === source[path[i]]) {
+			if (_isArray(source[path[i]])) {
+				dest[path[i]] = source[path[i]].slice();
+			} else {
+				dest[path[i]] = _assign({}, source[path[i]]);
+			}
+		}
+
+		source = source[path[i]];
+		dest = dest[path[i]];
+	}
+}
+
+function createTransaction(source) {
+	if (!_isPlainObject(source)) {
+		throw new Error('Source must be a plain object. Got ' + source);
+	}
+
+	const result = _assign({}, source);
+	let committed = false;
+
+	const transaction = {
+		set: function set(path, value) {
+			if (arguments.length < 2) {
+				return;
+			}
+
+			path = !_isArray(path) ? path.split('.') : path;
+
+			ensureCloned(path.slice(0, -1), source, result);
+			objectPath.set(result, path, value);
+
+			return transaction;
+		},
+
+		del: function del(path) {
+			if (arguments.length < 1) {
+				return;
+			}
+
+			path = !_isArray(path) ? path.split('.') : path;
+
+			ensureCloned(path.slice(0, -1), source, result);
+			objectPath.del(result, path);
+
+			return transaction;
+		},
+
+		push: function push(path, value) {
+			if (arguments.length < 2) {
+				return;
+			}
+
+			ensureCloned(path, source, result);
+			objectPath.push(result, path, value);
+
+			return transaction;
+		},
+
+		assign: function assign(path, value) {
+			if (arguments.length < 2) {
+				return;
+			}
+
+			path = !_isArray(path) ? path.split('.') : path;
+
+			for (var k in value) {
+				if (value.hasOwnProperty(k)) {
+					this.set(path.concat(k), value[k]);
+				}
+			}
+
+			return transaction;
+		},
+
+		commit: () => {
+			committed = true;
+			return result
+		}
+	};
+
+	return transaction;
+}
+
+module.exports = createTransaction;

--- a/lib/object-path-immutable-transaction.js
+++ b/lib/object-path-immutable-transaction.js
@@ -1,26 +1,47 @@
 'use strict';
+
 const _assign = require('lodash.assign');
 const objectPath = require('object-path');
-const _isArray = require('lodash.isarray');
 const _isPlainObject = require('lodash.isplainobject');
 
-function ensureCloned(path, source, dest) {
-	if (!_isArray(path)) {
-		path = ('' + path).split('.');
-	}
+function normalizePath(path) {
+	return Array.isArray(path) ? path : ('' + path).split('.');
+}
 
-	// ensure all ancestor path segments are cloned
+/**
+ * Ensure all parts of a path in a destination object are cloned from its source
+ *
+ * This function expects a path expressed as a dot-delimited string or an array
+ * of strings, as well as a source object and a destination object. It then
+ * ensures that the value at each part of the path in the destination is !== to
+ * the value at the same part of the path in the source. If any values are ===,
+ * it clones the value in the destination.
+ *
+ * All values in the source are assumed to be either an array or a plain object.
+ *
+ * @param {string|Array} path - the path to check
+ * @param {Object} source - the source object
+ * @param {Object} dest - the destination object
+ */
+function ensureCloned(path, source, dest) {
+	path = normalizePath(path);
+
+	// ensure all ancestor path segments are cloned by starting from the root of
+	// the path and cloning any that have the same value in source and destination
 	for (let i = 0; i < path.length; i++) {
-		if (dest[path[i]] === source[path[i]]) {
-			if (_isArray(source[path[i]])) {
-				dest[path[i]] = source[path[i]].slice();
+		let key = path[i];
+
+		if (dest[key] === source[key]) {
+			// the destination value is identical to the source value, so clone it
+			if (Array.isArray(source[key])) {
+				dest[key] = source[key].slice();
 			} else {
-				dest[path[i]] = _assign({}, source[path[i]]);
+				dest[key] = _assign({}, source[key]);
 			}
 		}
 
-		source = source[path[i]];
-		dest = dest[path[i]];
+		source = source[key];
+		dest = dest[key];
 	}
 }
 
@@ -38,7 +59,7 @@ function createTransaction(source) {
 				return;
 			}
 
-			path = !_isArray(path) ? path.split('.') : path;
+			path = normalizePath(path);
 
 			ensureCloned(path.slice(0, -1), source, result);
 			objectPath.set(result, path, value);
@@ -51,7 +72,7 @@ function createTransaction(source) {
 				return;
 			}
 
-			path = !_isArray(path) ? path.split('.') : path;
+			path = normalizePath(path);
 
 			ensureCloned(path.slice(0, -1), source, result);
 			objectPath.del(result, path);
@@ -75,7 +96,7 @@ function createTransaction(source) {
 				return;
 			}
 
-			path = !_isArray(path) ? path.split('.') : path;
+			path = normalizePath(path);
 
 			for (var k in value) {
 				if (value.hasOwnProperty(k)) {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "lodash.assign": "^4.0.9",
     "lodash.get": "^4.3.0",
     "lodash.has": "^4.4.0",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isplainobject": "^4.0.4",
     "lodash.mapvalues": "^4.4.0",
     "lodash.merge": "^4.4.0",
     "lodash.omit": "^4.3.0",
     "lodash.set": "^4.2.0",
+    "object-path": "^0.11.1",
     "object-path-immutable": "^0.4.0"
   },
   "devDependencies": {

--- a/test/object-path-immutable-transaction.js
+++ b/test/object-path-immutable-transaction.js
@@ -157,6 +157,15 @@ tap.test('object-path-immutable-transaction', t => {
 			t.end();
 		});
 
+		t.test('throws if called after `commit`', t => {
+			const transaction = immutableTransaction({});
+
+			transaction.commit();
+			t.throws(() => transaction.set('foo', 'bar'));
+
+			t.end();
+		});
+
 		t.end();
 	});
 
@@ -291,6 +300,17 @@ tap.test('object-path-immutable-transaction', t => {
 				transaction,
 				'returns the transaction'
 			);
+
+			t.end();
+		});
+
+		t.test('throws if called after `commit`', t => {
+			const transaction = immutableTransaction({
+				foo: 'bar'
+			});
+
+			transaction.commit();
+			t.throws(() => transaction.del('foo'));
 
 			t.end();
 		});
@@ -433,6 +453,17 @@ tap.test('object-path-immutable-transaction', t => {
 			t.end();
 		});
 
+		t.test('throws if called after `commit`', t => {
+			const transaction = immutableTransaction({
+				foo: []
+			});
+
+			transaction.commit();
+			t.throws(() => transaction.push('foo', 'bar'));
+
+			t.end();
+		});
+
 		t.end();
 	});
 
@@ -516,7 +547,6 @@ tap.test('object-path-immutable-transaction', t => {
 			'set not called for inherited properties'
 		);
 
-
 		t.test('does nothing if not passed enough arguments', t => {
 			const source = {
 				foo: {
@@ -570,6 +600,17 @@ tap.test('object-path-immutable-transaction', t => {
 				transaction,
 				'returns the transaction'
 			);
+
+			t.end();
+		});
+
+		t.test('throws if called after `commit`', t => {
+			const transaction = immutableTransaction({
+				foo: {}
+			});
+
+			transaction.commit();
+			t.throws(() => transaction.assign('foo', { bar: 'applesauce' }));
 
 			t.end();
 		});

--- a/test/object-path-immutable-transaction.js
+++ b/test/object-path-immutable-transaction.js
@@ -1,0 +1,581 @@
+'use strict';
+
+const tap = require('tap');
+const sinon = require('sinon');
+const immutableTransaction =
+	require('../lib/object-path-immutable-transaction');
+
+tap.test('object-path-immutable-transaction', t => {
+	t.type(immutableTransaction, 'function', 'exports a function');
+	t.throws(() => immutableTransaction(), 'requires an argument');
+
+	t.test('return value', t => {
+		t.type(immutableTransaction({}), 'object', 'object');
+		t.type(immutableTransaction({}).set, 'function', 'implements `set`');
+		t.type(immutableTransaction({}).del, 'function', 'implements `del`');
+		t.type(immutableTransaction({}).push, 'function', 'implements `push`');
+		t.type(immutableTransaction({}).assign, 'function', 'implements `assign`');
+
+		t.end();
+	});
+
+	t.test('set', t => {
+		t.test('does nothing if not passed enough arguments', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				},
+				fiz: ['buzz']
+			};
+			const transaction = immutableTransaction(source);
+
+			t.doesNotThrow(() => transaction.set());
+			t.doesNotThrow(() => transaction.set('foo.bar'));
+			t.same(transaction.commit(), source);
+
+			t.end();
+		});
+
+		t.test('sets the passed value at the specified path', t => {
+			const transaction = immutableTransaction({
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				},
+				fiz: ['buzz']
+			});
+
+			transaction.set('foo.bar.applesauce', 'jam');
+			transaction.set('foo.baz', []);
+			transaction.set('foo.baz.0', 'zero');
+			transaction.set('fiz.0', 'biz');
+			transaction.set('frob', 'nard');
+
+			const result = transaction.commit();
+			t.same(
+				result,
+				{
+					foo: {
+						bar: {
+							applesauce: 'jam'
+						},
+						baz: ['zero']
+					},
+					fiz: ['biz'],
+					frob: 'nard'
+				}
+			);
+			t.type(result.fiz, 'Array', 'arrays are cloned correctly');
+
+			t.end();
+		});
+
+		t.test('also accepts the path as an array', t => {
+			const transaction = immutableTransaction({
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				}
+			});
+
+			transaction.set(['foo', 'bar', 'applesauce'], 'jam');
+
+			const result = transaction.commit();
+			t.same(
+				result,
+				{
+					foo: {
+						bar: {
+							applesauce: 'jam'
+						}
+					}
+				}
+			);
+
+			t.end();
+		});
+
+		t.test('ensures that all members of the path are cloned', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				},
+				fiz: ['buzz']
+			};
+			const transaction = immutableTransaction(source);
+
+			transaction.set('foo.bar.applesauce', 'jam');
+			transaction.set('fiz.0', 'biz');
+
+			const result = transaction.commit();
+			t.notStrictEqual(result.foo, source.foo);
+			t.notStrictEqual(result.foo.bar, source.foo.bar);
+			t.notStrictEqual(result.fiz, source.fiz);
+			t.notStrictEqual(result.fiz[0], source.fiz[0]);
+
+			t.end();
+		});
+
+		t.test('unaffected paths are not cloned', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney',
+						unaffected: {}
+					},
+					unaffected: {}
+				},
+				unaffected: {}
+			};
+			const transaction = immutableTransaction(source);
+
+			transaction.set('foo.bar.applesauce', 'jam');
+
+			const result = transaction.commit();
+			t.strictEqual(result.unaffected, source.unaffected);
+			t.strictEqual(result.foo.unaffected, source.foo.unaffected);
+			t.strictEqual(result.foo.bar.unaffected, source.foo.bar.unaffected);
+
+			t.end();
+		});
+
+		t.test('is chainable', t => {
+			const transaction = immutableTransaction({});
+
+			t.strictEqual(
+				transaction.set('foo', 'bar'),
+				transaction,
+				'returns the transaction'
+			);
+
+			t.end();
+		});
+
+		t.end();
+	});
+
+	t.test('del', t => {
+		t.test('does nothing if not passed enough arguments', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				},
+				fiz: ['buzz']
+			};
+			const transaction = immutableTransaction(source);
+
+			t.doesNotThrow(() => transaction.del());
+			t.same(transaction.commit(), source);
+
+			t.end();
+		});
+
+		t.test('deletes the value at the specified path', t => {
+			const transaction = immutableTransaction({
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					},
+					baz: {
+						quux: 'lol'
+					}
+				},
+				fiz: ['buzz', 'biz']
+			});
+
+			transaction.del('foo.bar.applesauce');
+			transaction.del('foo.baz');
+			transaction.del('fiz.0');
+
+			const result = transaction.commit();
+			t.same(
+				result,
+				{
+					foo: {
+						bar: {
+						}
+					},
+					fiz: ['biz']
+				}
+			);
+			t.type(result.fiz, 'Array', 'arrays are cloned correctly');
+
+			t.end();
+		});
+
+		t.test('also accepts the path as an array', t => {
+			const transaction = immutableTransaction({
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				}
+			});
+
+			transaction.del(['foo', 'bar', 'applesauce']);
+
+			const result = transaction.commit();
+			t.same(
+				result,
+				{
+					foo: {
+						bar: {
+						}
+					}
+				}
+			);
+
+			t.end();
+		});
+
+		t.test('ensures that all members of the path are cloned', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				},
+				fiz: ['buzz']
+			};
+			const transaction = immutableTransaction(source);
+
+			transaction.del('foo.bar.applesauce');
+			transaction.del('fiz.0');
+
+			const result = transaction.commit();
+			t.notStrictEqual(result.foo, source.foo);
+			t.notStrictEqual(result.foo.bar, source.foo.bar);
+			t.notStrictEqual(result.fiz, source.fiz);
+
+			t.end();
+		});
+
+		t.test('unaffected paths are not cloned', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney',
+						unaffected: {}
+					},
+					unaffected: {}
+				},
+				unaffected: {}
+			};
+			const transaction = immutableTransaction(source);
+
+			transaction.del('foo.bar.applesauce');
+
+			const result = transaction.commit();
+			t.strictEqual(result.unaffected, source.unaffected);
+			t.strictEqual(result.foo.unaffected, source.foo.unaffected);
+			t.strictEqual(result.foo.bar.unaffected, source.foo.bar.unaffected);
+
+			t.end();
+		});
+
+		t.test('is chainable', t => {
+			const transaction = immutableTransaction({
+				foo: 'bar'
+			});
+
+			t.strictEqual(
+				transaction.del('foo'),
+				transaction,
+				'returns the transaction'
+			);
+
+			t.end();
+		});
+
+		t.end();
+	});
+
+	t.test('push', t => {
+		t.test('does nothing if not passed enough arguments', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				},
+				fiz: ['buzz']
+			};
+			const transaction = immutableTransaction(source);
+
+			t.doesNotThrow(() => transaction.push());
+			t.doesNotThrow(() => transaction.push('fiz'));
+			t.same(transaction.commit(), source);
+
+			t.end();
+		});
+
+		t.test('pushes the value onto the array at the specified path', t => {
+			const transaction = immutableTransaction({
+				foo: {
+					bar: {
+						applesauce: ['chutney']
+					}
+				},
+				fiz: ['buzz']
+			});
+
+			transaction.push('foo.bar.applesauce', 'jam');
+			transaction.push('fiz', 'biz');
+
+			const result = transaction.commit();
+			t.same(
+				result,
+				{
+					foo: {
+						bar: {
+							applesauce: ['chutney', 'jam']
+						}
+					},
+					fiz: ['buzz', 'biz']
+				}
+			);
+			t.type(result.foo.bar.applesauce, 'Array', 'arrays are cloned correctly');
+			t.type(result.fiz, 'Array', 'arrays are cloned correctly');
+
+			t.end();
+		});
+
+		t.test('also accepts the path as an array', t => {
+			const transaction = immutableTransaction({
+				foo: {
+					bar: {
+						applesauce: ['chutney']
+					}
+				}
+			});
+
+			transaction.push(['foo', 'bar', 'applesauce'], 'jam');
+
+			const result = transaction.commit();
+			t.same(
+				result,
+				{
+					foo: {
+						bar: {
+							applesauce: ['chutney', 'jam']
+						}
+					}
+				}
+			);
+
+			t.end();
+		});
+
+		t.test('ensures that all members of the path are cloned', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: ['chutney']
+					}
+				},
+				fiz: ['buzz']
+			};
+			const transaction = immutableTransaction(source);
+
+			transaction.push('foo.bar.applesauce', 'jam');
+			transaction.push('fiz', 'biz');
+
+			const result = transaction.commit();
+			t.notStrictEqual(result.foo, source.foo);
+			t.notStrictEqual(result.foo.bar, source.foo.bar);
+			t.notStrictEqual(result.fiz, source.fiz);
+
+			t.end();
+		});
+
+		t.test('unaffected paths are not cloned', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: ['chutney'],
+						unaffected: {}
+					},
+					unaffected: {}
+				},
+				unaffected: {}
+			};
+			const transaction = immutableTransaction(source);
+
+			transaction.push('foo.bar.applesauce', 'jam');
+
+			const result = transaction.commit();
+			t.strictEqual(result.unaffected, source.unaffected);
+			t.strictEqual(result.foo.unaffected, source.foo.unaffected);
+			t.strictEqual(result.foo.bar.unaffected, source.foo.bar.unaffected);
+
+			t.end();
+		});
+
+		t.test('is chainable', t => {
+			const transaction = immutableTransaction({
+				foo: []
+			});
+
+			t.strictEqual(
+				transaction.push('foo', 'bar'),
+				transaction,
+				'returns the transaction'
+			);
+
+			t.end();
+		});
+
+		t.end();
+	});
+
+	t.test('assign', t => {
+		let transaction = immutableTransaction({
+			foo: {
+				bar: {
+					applesauce: ['chutney']
+				}
+			},
+			fiz: ['buzz']
+		});
+
+		sinon.spy(transaction, 'set');
+
+		let toAssign = {
+			bar: 'applesauce',
+			baz: {
+				frob: ['nard']
+			}
+		};
+		transaction.assign('foo', toAssign);
+
+		t.strictEqual(
+			transaction.set.callCount,
+			2,
+			'set called once for each own property of passed object'
+		);
+		t.ok(
+			transaction.set.calledWithExactly(['foo', 'bar'], toAssign.bar),
+			'set called with own property key and value'
+		);
+		t.ok(
+			transaction.set.calledWithExactly(['foo', 'baz'], toAssign.baz),
+			'set called with own property key and value'
+		);
+
+		transaction.set.reset();
+		toAssign = {
+			fiz: 'buzz',
+			fuzz: 'biz'
+		};
+		transaction.assign('foo.baz', toAssign);
+		t.strictEqual(
+			transaction.set.callCount,
+			2,
+			'set called once for each own property of passed object'
+		);
+		t.ok(
+			transaction.set.calledWithExactly(['foo', 'baz', 'fiz'], toAssign.fiz),
+			'set called with own property key and value'
+		);
+		t.ok(
+			transaction.set.calledWithExactly(['foo', 'baz', 'fuzz'], toAssign.fuzz),
+			'set called with own property key and value'
+		);
+
+		transaction.set.reset();
+		toAssign = {
+			fiz: 'buzz'
+		};
+		transaction.assign(['foo', 'baz'], toAssign);
+		t.strictEqual(
+			transaction.set.callCount,
+			1,
+			'path can also be an array'
+		);
+		t.ok(
+			transaction.set.calledWithExactly(['foo', 'baz', 'fiz'], toAssign.fiz),
+			'path can also be an array'
+		);
+
+		transaction.set.reset();
+		toAssign = Object.create({
+			fiz: 'buzz'
+		});
+		transaction.assign('foo.baz', toAssign);
+		t.strictEqual(
+			transaction.set.callCount,
+			0,
+			'set not called for inherited properties'
+		);
+
+
+		t.test('does nothing if not passed enough arguments', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney'
+					}
+				},
+				fiz: ['buzz']
+			};
+			const transaction = immutableTransaction(source);
+
+			t.doesNotThrow(() => transaction.assign());
+			t.doesNotThrow(() => transaction.assign('foo.bar'));
+			t.same(transaction.commit(), source);
+
+			t.end();
+		});
+
+		t.test('unaffected paths are not cloned', t => {
+			const source = {
+				foo: {
+					bar: {
+						applesauce: 'chutney',
+						unaffected: {}
+					},
+					unaffected: {}
+				},
+				unaffected: {}
+			};
+			const transaction = immutableTransaction(source);
+
+			transaction.assign('foo.bar', {
+				applesauce: 'jam'
+			});
+
+			const result = transaction.commit();
+			t.strictEqual(result.unaffected, source.unaffected);
+			t.strictEqual(result.foo.unaffected, source.foo.unaffected);
+			t.strictEqual(result.foo.bar.unaffected, source.foo.bar.unaffected);
+
+			t.end();
+		});
+
+		t.test('is chainable', t => {
+			const transaction = immutableTransaction({
+				foo: null
+			});
+
+			t.strictEqual(
+				transaction.assign('foo', {}),
+				transaction,
+				'returns the transaction'
+			);
+
+			t.end();
+		});
+
+		t.end();
+	});
+
+	t.end();
+});


### PR DESCRIPTION
As described in #7, repeatedly performing immutable updates can be very slow.
One part of the problem is that object-path-immutable doesn't provide a facility
for performing multiple operations on an object and then returning a single new
object with all affected paths cloned. For example:

```
let o = { foo: { bar: {} } };
o = objectPathImmutable.set(o, 'foo.bar.applesauce', 'chutney');
o = objectPathImmutable.set(o, 'foo.bar.jam', 'marmelade');
```

Both `foo` and `bar` are cloned twice in the above code. What we would like
instead is to perform an immutable transaction. This patch implements an API
that supports the same operations as object-path-immutable, but performed as a
transaction.

This is partial progress toward fixing #7.

---

# Benchmark

## Code

<details>
<summary>`quick-benchmark.js`</summary>
```javascript
'use strict';

const immutable = require('object-path-immutable');
const immutableTransaction = require('./lib/object-path-immutable-transaction');
const uuid = require('uuid');
const lorem = require('lorem-ipsum');
const assert = require('assert');
require('console.table');

function hrtimeToMs(hrtime) {
  return hrtime[0] * 1000 + hrtime[1] / 1e6;
}

function generateData(N) {
  const data = [];
  for (let i = 0; i < N; i++) {
    data.push({
      id: uuid.v4(),
      value: lorem({ count: 10, units: 'words' })
    });
  }

	return data;
}

function runTrial(initial, data, fn) {
	const start = process.hrtime();

	data.reduce(fn, initial);

	return hrtimeToMs(process.hrtime(start));
}

const original = {
	foo: {
	}
};

const results = [
	100,
	200,
	400,
	800
].map(N => {
	const data = generateData(N);
	const result = {
		N
	};

	let control;
	result['object-path-immutable'] =
		runTrial(original, data, (o, datum, i) => {
			o = immutable.set(o, `foo.${datum.id}`, datum.value);

			if (i === N - 1) {
				control = o;
			}

			return o;
		});

	result['object-path-immutable-transaction'] =
		runTrial(original, data, (o, datum, i) => {
			if (i === 0) {
				o = immutableTransaction(o);
			}

			o = o.set(`foo.${datum.id}`, datum.value);

			if (i === N - 1) {
				o = o.commit();
				assert.deepEqual(control, o);
			}

			return o;
		});

	return result;
});
console.table(results);

```
</details>

## Results

```
$ node quick-benchmark.js
N    object-path-immutable  object-path-immutable-transaction
---  ---------------------  ---------------------------------
100  5.735478               3.18941
200  13.796613              1.59718
400  51.963328              2.004868
800  209.149855             3.027543
```


---

- [x] `normalizePath` helper
- [x] store `path[i]` in a variable in `ensureCloned`
- [x] comments for `ensureCloned`
- [x] throw if mutators called after `commit`