### PR TITLE
add npmignore so that dist directory is published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+*
+!dist/**/*
+!index.js
+!lib/**/*
+!README.md
+!LICENSE


### PR DESCRIPTION
the 1.1.1 publish did not include the dist/ directory as anticipated due to the fact that it is in the gitingore. The workaround is to include an npmignore file that explicitly excludes everything and only publishes that which is desired.